### PR TITLE
Fix enums and webhook event property

### DIFF
--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -7,11 +7,11 @@ import { RateLimitInfo, WasenderSuccessResponse } from "./messages.ts";
 
 // ---------- Session Data Structures ----------
 
-export type WhatsAppSessionStatus = 
+export type WhatsAppSessionStatus =
   | "connected"
   | "disconnected"
   | "need_scan"
-  | "connecting" 
+  | "connecting"
   | "logged_out"
   | "expired";
 

--- a/src/webhook.ts
+++ b/src/webhook.ts
@@ -252,8 +252,8 @@ export type WasenderWebhookEvent =
 /*
 // Example of how to process different event types after parsing:
 function processParsedWebhookEvent(event: WasenderWebhookEvent) {
-  console.log('Processing event type:', event.type);
-  switch (event.type) {
+  console.log('Processing event type:', event.event);
+  switch (event.event) {
     case WasenderWebhookEventType.MessagesUpsert:
       console.log('New message from:', event.data.key.remoteId, 'ID:', event.data.key.id);
       if (event.data.message?.conversation) {

--- a/tests/sessions.ts
+++ b/tests/sessions.ts
@@ -51,7 +51,7 @@ describe('Session Type Definitions', () => {
     id: 1,
     name: 'Business WhatsApp',
     phone_number: '+1234567890',
-    status: 'CONNECTED',
+    status: 'connected',
     account_protection: true,
     log_messages: true,
     webhook_url: 'https://example.com/webhook',
@@ -66,15 +66,15 @@ describe('Session Type Definitions', () => {
       const session: WhatsAppSession = { ...mockWhatsAppSession };
       expect(session.id).toBe(1);
       expect(session.name).toBe('Business WhatsApp');
-      expect(session.status).toBe<WhatsAppSessionStatus>('CONNECTED');
+      expect(session.status).toBe<WhatsAppSessionStatus>('connected');
       expect(session.webhook_events).toEqual(['message', 'group_update']);
     });
 
     it('WhatsAppSessionStatus type should allow valid statuses', () => {
-      const status1: WhatsAppSessionStatus = 'CONNECTED';
-      const status2: WhatsAppSessionStatus = 'NEED_SCAN';
-      expect(status1).toBe('CONNECTED');
-      expect(status2).toBe('NEED_SCAN');
+      const status1: WhatsAppSessionStatus = 'connected';
+      const status2: WhatsAppSessionStatus = 'need_scan';
+      expect(status1).toBe('connected');
+      expect(status2).toBe('need_scan');
     });
   });
 
@@ -126,19 +126,19 @@ describe('Session Type Definitions', () => {
   describe('API Response Data Structures', () => {
     it('ConnectSessionResponseData type should be correct (NEED_SCAN)', () => {
       const data: ConnectSessionResponseData = {
-        status: 'NEED_SCAN',
+        status: 'need_scan',
         qrCode: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACA...',
       };
-      expect(data.status).toBe<WhatsAppSessionStatus>('NEED_SCAN');
+      expect(data.status).toBe<WhatsAppSessionStatus>('need_scan');
       expect(data.qrCode).toBe('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACA...');
     });
     
     it('ConnectSessionResponseData type should be correct (CONNECTED)', () => {
       const data: ConnectSessionResponseData = {
-        status: 'CONNECTED',
+        status: 'connected',
         message: 'Session already connected'
       };
-      expect(data.status).toBe<WhatsAppSessionStatus>('CONNECTED');
+      expect(data.status).toBe<WhatsAppSessionStatus>('connected');
       expect(data.message).toBe('Session already connected');
       expect(data.qrCode).toBeUndefined();
     });
@@ -152,10 +152,10 @@ describe('Session Type Definitions', () => {
 
     it('DisconnectSessionResponseData type should be correct', () => {
       const data: DisconnectSessionResponseData = {
-        status: 'DISCONNECTED',
+        status: 'disconnected',
         message: 'WhatsApp session disconnected successfully',
       };
-      expect(data.status).toBe<WhatsAppSessionStatus>('DISCONNECTED');
+      expect(data.status).toBe<WhatsAppSessionStatus>('disconnected');
       expect(data.message).toBe('WhatsApp session disconnected successfully');
     });
     
@@ -169,8 +169,8 @@ describe('Session Type Definitions', () => {
     });
 
     it('SessionStatusData type should be correct', () => {
-      const data: SessionStatusData = { status: 'CONNECTED' };
-      expect(data.status).toBe<WhatsAppSessionStatus>('CONNECTED');
+      const data: SessionStatusData = { status: 'connected' };
+      expect(data.status).toBe<WhatsAppSessionStatus>('connected');
     });
   });
 
@@ -179,13 +179,13 @@ describe('Session Type Definitions', () => {
       const response: GetAllWhatsAppSessionsResponse = {
         success: true,
         message: 'Sessions retrieved successfully',
-        data: [mockWhatsAppSession, { ...mockWhatsAppSession, id: 2, name: 'Support WhatsApp', status: 'DISCONNECTED' }],
+        data: [mockWhatsAppSession, { ...mockWhatsAppSession, id: 2, name: 'Support WhatsApp', status: 'disconnected' }],
       };
       expect(response.success).toBe(true);
       expect(response.message).toBe('Sessions retrieved successfully');
       expect(response.data.length).toBe(2);
       expect(response.data[0].id).toBe(1);
-      expect(response.data[1].status).toBe<WhatsAppSessionStatus>('DISCONNECTED');
+      expect(response.data[1].status).toBe<WhatsAppSessionStatus>('disconnected');
     });
 
     it('GetWhatsAppSessionDetailsResponse type should be correct', () => {
@@ -203,12 +203,12 @@ describe('Session Type Definitions', () => {
       const response: CreateWhatsAppSessionResponse = {
         success: true,
         message: 'Session created successfully',
-        data: { ...mockWhatsAppSession, id: 3, status: 'DISCONNECTED' },
+        data: { ...mockWhatsAppSession, id: 3, status: 'disconnected' },
       };
       expect(response.success).toBe(true);
       expect(response.message).toBe('Session created successfully');
       expect(response.data.id).toBe(3);
-      expect(response.data.status).toBe<WhatsAppSessionStatus>('DISCONNECTED');
+      expect(response.data.status).toBe<WhatsAppSessionStatus>('disconnected');
     });
 
     it('UpdateWhatsAppSessionResponse type should be correct', () => {
@@ -237,11 +237,11 @@ describe('Session Type Definitions', () => {
       const response: ConnectSessionResponse = {
         success: true,
         message: 'Connect action processed',
-        data: { status: 'NEED_SCAN', qrCode: 'qrdata...' },
+        data: { status: 'need_scan', qrCode: 'qrdata...' },
       };
       expect(response.success).toBe(true);
       expect(response.message).toBe('Connect action processed');
-      expect(response.data.status).toBe<WhatsAppSessionStatus>('NEED_SCAN');
+      expect(response.data.status).toBe<WhatsAppSessionStatus>('need_scan');
     });
 
     it('GetQRCodeResponse type should be correct', () => {
@@ -259,18 +259,18 @@ describe('Session Type Definitions', () => {
       const response: DisconnectSessionResponse = {
         success: true,
         message: 'Disconnect action processed',
-        data: { status: 'DISCONNECTED', message: 'Disconnected.' },
+        data: { status: 'disconnected', message: 'Disconnected.' },
       };
       expect(response.success).toBe(true);
       expect(response.message).toBe('Disconnect action processed');
-      expect(response.data.status).toBe<WhatsAppSessionStatus>('DISCONNECTED');
+      expect(response.data.status).toBe<WhatsAppSessionStatus>('disconnected');
     });
     
     it('GetSessionStatusResponse type should be correct (special structure)', () => {
       const response: GetSessionStatusResponse = {
-        status: 'CONNECTED',
+        status: 'connected',
       };
-      expect(response.status).toBe<WhatsAppSessionStatus>('CONNECTED');
+      expect(response.status).toBe<WhatsAppSessionStatus>('connected');
       // Check for absence of success/data fields if that's the contract
       expect((response as any).success).toBeUndefined();
       expect((response as any).data).toBeUndefined();
@@ -310,7 +310,7 @@ describe('Session Type Definitions', () => {
         rateLimit: mockRateLimitInfo,
       };
       expect(result.response.message).toBe('Session created');
-      expect(result.response.data.status).toBe('CONNECTED');
+      expect(result.response.data.status).toBe('connected');
       expect(result.rateLimit).toBeDefined();
       if (result.rateLimit) {
         expect(result.rateLimit.limit).toBe(100);
@@ -345,7 +345,7 @@ describe('Session Type Definitions', () => {
 
     it('ConnectSessionResult type should be correct', () => {
       const result: ConnectSessionResult = {
-        response: { success: true, message: 'Connect action done', data: { status: 'NEED_SCAN', qrCode: 'testQR' } },
+        response: { success: true, message: 'Connect action done', data: { status: 'need_scan', qrCode: 'testQR' } },
         rateLimit: mockRateLimitInfo,
       };
       expect(result.response.message).toBe('Connect action done');
@@ -371,7 +371,7 @@ describe('Session Type Definitions', () => {
 
     it('DisconnectSessionResult type should be correct', () => {
       const result: DisconnectSessionResult = {
-        response: { success: true, message: 'Disconnected action performed', data: { status: 'DISCONNECTED', message: 'Done' } },
+        response: { success: true, message: 'Disconnected action performed', data: { status: 'disconnected', message: 'Done' } },
         rateLimit: mockRateLimitInfo,
       };
       expect(result.response.message).toBe('Disconnected action performed');
@@ -396,10 +396,10 @@ describe('Session Type Definitions', () => {
     
     it('GetSessionStatusResult type should be correct', () => {
       const result: GetSessionStatusResult = {
-        response: { status: 'LOGGED_OUT' },
+        response: { status: 'logged_out' },
         rateLimit: mockRateLimitInfo,
       };
-      expect(result.response.status).toBe<WhatsAppSessionStatus>('LOGGED_OUT');
+      expect(result.response.status).toBe<WhatsAppSessionStatus>('logged_out');
       expect(result.rateLimit).toBeDefined();
       if (result.rateLimit) {
         expect(result.rateLimit.remaining).toBe(99);
@@ -441,7 +441,7 @@ describe('Session endpoints personal token tests', () => {
       ok: true,
       status: 200,
       headers: new Headers(),
-      json: () => Promise.resolve({ status: 'CONNECTED' })
+      json: () => Promise.resolve({ status: 'connected' })
     }) as jest.MockedFunction<FetchImplementation>;
 
     const testWasender = createWasender(apiKey, personalAccessToken, undefined, mockFetch);
@@ -481,7 +481,7 @@ describe('Session endpoints personal token tests', () => {
         data: {
           id: 1,
           name: 'Test Session',
-          status: 'DISCONNECTED'
+          status: 'disconnected'
         }
       })
     }) as jest.MockedFunction<FetchImplementation>;

--- a/tests/webhook.ts
+++ b/tests/webhook.ts
@@ -68,11 +68,11 @@ describe('Webhook handler', () => {
   };
 
   it('rejects missing signature', async () => {
-    await expect(handleWebhook(makeReq({ type: 'something' }))).rejects.toThrow('Invalid signature');
+    await expect(handleWebhook(makeReq({ event: 'something' }))).rejects.toThrow('Invalid signature');
   });
 
   it('rejects incorrect signature', async () => {
-    await expect(handleWebhook(makeReq({ type: 'something' }, 'wrongsecret'))).rejects.toThrow('Invalid signature');
+    await expect(handleWebhook(makeReq({ event: 'something' }, 'wrongsecret'))).rejects.toThrow('Invalid signature');
   });
 
   describe('Event Type Parsing', () => {
@@ -84,14 +84,14 @@ describe('Webhook handler', () => {
         unreadCount: 2,
       };
       const payload: ChatsUpsertEvent = {
-        type: WasenderWebhookEventType.ChatsUpsert,
+        event: WasenderWebhookEventType.ChatsUpsert,
         timestamp: 1633456789,
         data: [chatEntry],
         sessionId: 'session-id-123',
       };
     const req = makeReq(payload, SECRET);
     const evt = await handleWebhook(req);
-      expect(evt.type).toBe(WasenderWebhookEventType.ChatsUpsert);
+      expect(evt.event).toBe(WasenderWebhookEventType.ChatsUpsert);
       expect(evt.data).toEqual([chatEntry]);
       expect(evt.timestamp).toBe(1633456789);
       expect(evt.sessionId).toBe('session-id-123');
@@ -104,23 +104,23 @@ describe('Webhook handler', () => {
             conversationTimestamp: 1633456789
         };
         const payload: ChatsUpdateEvent = {
-            type: WasenderWebhookEventType.ChatsUpdate,
+            event: WasenderWebhookEventType.ChatsUpdate,
             timestamp: 1633456789,
             data: [chatUpdateData]
         };
         const evt = await handleWebhook(makeReq(payload, SECRET)) as ChatsUpdateEvent;
-        expect(evt.type).toBe(WasenderWebhookEventType.ChatsUpdate);
+        expect(evt.event).toBe(WasenderWebhookEventType.ChatsUpdate);
         expect(evt.data).toEqual([chatUpdateData]);
     });
 
     it('parses ChatsDeleteEvent correctly', async () => {
         const payload: ChatsDeleteEvent = {
-            type: WasenderWebhookEventType.ChatsDelete,
+            event: WasenderWebhookEventType.ChatsDelete,
             timestamp: 1633456789,
             data: ["1234567890"]
         };
         const evt = await handleWebhook(makeReq(payload, SECRET)) as ChatsDeleteEvent;
-        expect(evt.type).toBe(WasenderWebhookEventType.ChatsDelete);
+        expect(evt.event).toBe(WasenderWebhookEventType.ChatsDelete);
         expect(evt.data).toEqual(["1234567890"]);
     });
 
@@ -136,12 +136,12 @@ describe('Webhook handler', () => {
         participants: [participant1, participant2],
       };
       const payload: GroupsUpsertEvent = {
-        type: WasenderWebhookEventType.GroupsUpsert,
+        event: WasenderWebhookEventType.GroupsUpsert,
         timestamp: 1633456789,
         data: [groupData],
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.GroupsUpsert);
+      expect(evt.event).toBe(WasenderWebhookEventType.GroupsUpsert);
       expect(evt.data).toEqual([groupData]);
     });
     
@@ -152,12 +152,12 @@ describe('Webhook handler', () => {
             restrict: false
         };
         const payload: GroupsUpdateEvent = {
-            type: WasenderWebhookEventType.GroupsUpdate,
+            event: WasenderWebhookEventType.GroupsUpdate,
             timestamp: 1633456789,
             data: [groupUpdateData]
         };
         const evt = await handleWebhook(makeReq(payload, SECRET)) as GroupsUpdateEvent;
-        expect(evt.type).toBe(WasenderWebhookEventType.GroupsUpdate);
+        expect(evt.event).toBe(WasenderWebhookEventType.GroupsUpdate);
         expect(evt.data).toEqual([groupUpdateData]);
     });
 
@@ -168,12 +168,12 @@ describe('Webhook handler', () => {
         action: 'add',
       };
       const payload: GroupParticipantsUpdateEvent = {
-        type: WasenderWebhookEventType.GroupParticipantsUpdate,
+        event: WasenderWebhookEventType.GroupParticipantsUpdate,
         timestamp: 1633456789,
         data: participantsUpdateData,
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.GroupParticipantsUpdate);
+      expect(evt.event).toBe(WasenderWebhookEventType.GroupParticipantsUpdate);
       expect(evt.data).toEqual(participantsUpdateData);
     });
 
@@ -186,12 +186,12 @@ describe('Webhook handler', () => {
         status: 'Hey there! I am using WhatsApp.',
       };
       const payload: ContactsUpsertEvent = {
-        type: WasenderWebhookEventType.ContactsUpsert,
+        event: WasenderWebhookEventType.ContactsUpsert,
         timestamp: 1633456789,
         data: [contactData],
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.ContactsUpsert);
+      expect(evt.event).toBe(WasenderWebhookEventType.ContactsUpsert);
       expect(evt.data).toEqual([contactData]);
     });
 
@@ -201,12 +201,12 @@ describe('Webhook handler', () => {
             imgUrl: "https://pps.whatsapp.net/v/t61.24694-24/123456789_123456789_123456789_123456789_123456789.jpg"
         };
         const payload: ContactsUpdateEvent = {
-            type: WasenderWebhookEventType.ContactsUpdate,
+            event: WasenderWebhookEventType.ContactsUpdate,
             timestamp: 1633456789,
             data: [contactUpdateData]
         };
         const evt = await handleWebhook(makeReq(payload, SECRET)) as ContactsUpdateEvent;
-        expect(evt.type).toBe(WasenderWebhookEventType.ContactsUpdate);
+        expect(evt.event).toBe(WasenderWebhookEventType.ContactsUpdate);
         expect(evt.data).toEqual([contactUpdateData]);
     });
 
@@ -215,12 +215,12 @@ describe('Webhook handler', () => {
       const messageContent: MessageContent = { conversation: 'Hello, I have a question' };
       const messageData: MessagesUpsertData = { key: messageKey, message: messageContent };
       const payload: MessagesUpsertEvent = {
-        type: WasenderWebhookEventType.MessagesUpsert,
+        event: WasenderWebhookEventType.MessagesUpsert,
         timestamp: 1633456789,
         data: messageData,
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.MessagesUpsert);
+      expect(evt.event).toBe(WasenderWebhookEventType.MessagesUpsert);
       expect(evt.data).toEqual(messageData);
     });
 
@@ -229,12 +229,12 @@ describe('Webhook handler', () => {
       const messageUpdate: MessageUpdate = { status: 'delivered' };
       const updateEntry: MessagesUpdateDataEntry = { key: messageKey, update: messageUpdate };
       const payload: MessagesUpdateEvent = {
-        type: WasenderWebhookEventType.MessagesUpdate,
+        event: WasenderWebhookEventType.MessagesUpdate,
         timestamp: 1633456795,
         data: [updateEntry],
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.MessagesUpdate);
+      expect(evt.event).toBe(WasenderWebhookEventType.MessagesUpdate);
       expect(evt.data).toEqual([updateEntry]);
     });
     
@@ -245,14 +245,14 @@ describe('Webhook handler', () => {
             remoteId: "+1234567890"
         };
         const payload: MessagesDeleteEvent = {
-            type: WasenderWebhookEventType.MessagesDelete,
+            event: WasenderWebhookEventType.MessagesDelete,
             timestamp: 1633456800,
             data: {
                 keys: [messageKey]
             }
         };
         const evt = await handleWebhook(makeReq(payload, SECRET)) as MessagesDeleteEvent;
-        expect(evt.type).toBe(WasenderWebhookEventType.MessagesDelete);
+        expect(evt.event).toBe(WasenderWebhookEventType.MessagesDelete);
         expect(evt.data).toEqual({ keys: [messageKey] });
     });
 
@@ -261,36 +261,36 @@ describe('Webhook handler', () => {
       const messageContent: MessageContent = { conversation: 'This is my reply.' };
       const sentData: MessageSentData = { key: messageKey, message: messageContent, status: 'sent' };
       const payload: MessageSentEvent = {
-        type: WasenderWebhookEventType.MessageSent,
+        event: WasenderWebhookEventType.MessageSent,
         timestamp: 1633456790,
         data: sentData,
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.MessageSent);
+      expect(evt.event).toBe(WasenderWebhookEventType.MessageSent);
       expect(evt.data).toEqual(sentData);
     });
 
     it('parses SessionStatusEvent correctly', async () => {
       const statusData: SessionStatusData = { status: 'connected', session_id: 'session-id-123' };
       const payload: SessionStatusEvent = {
-        type: WasenderWebhookEventType.SessionStatus,
+        event: WasenderWebhookEventType.SessionStatus,
         timestamp: 1633456789,
         data: statusData,
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.SessionStatus);
+      expect(evt.event).toBe(WasenderWebhookEventType.SessionStatus);
       expect(evt.data).toEqual(statusData);
     });
 
     it('parses QrCodeUpdatedEvent correctly', async () => {
       const qrData: QrCodeUpdatedData = { qr: 'data:image/png;base64,...', session_id: 'session-id-123' };
       const payload: QrCodeUpdatedEvent = {
-        type: WasenderWebhookEventType.QrCodeUpdated,
+        event: WasenderWebhookEventType.QrCodeUpdated,
         timestamp: 1633456780,
         data: qrData,
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.QrCodeUpdated);
+      expect(evt.event).toBe(WasenderWebhookEventType.QrCodeUpdated);
       expect(evt.data).toEqual(qrData);
     });
 
@@ -299,12 +299,12 @@ describe('Webhook handler', () => {
       const reaction: Reaction = { text: '👍', key: reactionKey };
       const reactionEntry: MessagesReactionDataEntry = { key: reactionKey, reaction: reaction };
       const payload: MessagesReactionEvent = {
-        type: WasenderWebhookEventType.MessagesReaction,
+        event: WasenderWebhookEventType.MessagesReaction,
         timestamp: 1633456810,
         data: [reactionEntry],
       };
       const evt = await handleWebhook(makeReq(payload, SECRET));
-      expect(evt.type).toBe(WasenderWebhookEventType.MessagesReaction);
+      expect(evt.event).toBe(WasenderWebhookEventType.MessagesReaction);
       expect(evt.data).toEqual([reactionEntry]);
     });
 
@@ -313,13 +313,13 @@ describe('Webhook handler', () => {
         const receipt: Receipt = { userJid: 'recipient@s.whatsapp.net', status: 'read', t: 1633456815 };
         const receiptEntry: MessageReceiptUpdateDataEntry = { key: messageKey, receipt: receipt };
         const payload: MessageReceiptUpdateEvent = {
-            type: WasenderWebhookEventType.MessageReceiptUpdate,
+            event: WasenderWebhookEventType.MessageReceiptUpdate,
             timestamp: 1633456815,
             data: [receiptEntry],
             sessionId: 'session-1'
         };
         const evt = await handleWebhook(makeReq(payload, SECRET)) as MessageReceiptUpdateEvent;
-        expect(evt.type).toBe(WasenderWebhookEventType.MessageReceiptUpdate);
+        expect(evt.event).toBe(WasenderWebhookEventType.MessageReceiptUpdate);
         expect(evt.data).toEqual([receiptEntry]);
         expect(evt.sessionId).toBe('session-1');
     });


### PR DESCRIPTION
## Summary
- keep `BaseWebhookEvent` using the `event` field
- use lowercase strings for `WhatsAppSessionStatus`
- adjust tests for lowercase statuses and `event` field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f6d6db5f083309450cf4b8cf061dd